### PR TITLE
ci: Split cicd workflow into ci and cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,23 +1,16 @@
-name: ci/cd
+name: cd
 
 on:
   push:
     branches: [ master ]
-  pull_request:
 
 jobs:
-  # CI is run on pull requests and pushes to master (i.e merging PRs)
   ci:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - run: ./bin/make ci
+    uses: ./.github/workflows/ci.yaml
 
-  # Release is run only on pushes to master (i.e. merging PRs)
   release:
     runs-on: ubuntu-latest
     needs: [ ci ]
-    if: github.event_name == 'push'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -26,11 +19,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./bin/make release
 
-  # Send failure notification to slack if push to master job fails
   howl-on-fail:
     runs-on: ubuntu-latest
     needs: [ ci, release ]
-    if: failure() && github.event_name == 'push'
+    if: failure()
     steps:
     - uses: foxygoat/howl@v1
       env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: ci
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: ./bin/make ci


### PR DESCRIPTION

Split the ci/cd workflow into separate CI and CD workflows, the former
of which only runs on PRs. The CD workflow calls the CI workflow as a
reusable workflow and does the release and howl-on-fail.

This is to simplify the pull requests on github so they only show the CI
job and not the other two as skipped.
